### PR TITLE
スマホ時の公式サイトリンク集開くボタン位置を右上に移動

### DIFF
--- a/src/react-components/room/OfficialSiteLinksButtonContainer.scss
+++ b/src/react-components/room/OfficialSiteLinksButtonContainer.scss
@@ -4,8 +4,8 @@
   background: radial-gradient(ellipse at bottom, #1B2735 0%, #090A0F 100%);
   color: theme.$white;
   position: absolute;
-  left: 15px;
-  bottom: 15px;
+  right: 10px;
+  top: 65px;
   width: 80px;
   height: 80px;
   border-radius: 100px;


### PR DESCRIPTION
## 対応内容
- スマホ時の公式サイトリンク集開くボタン位置を右上に移動

## 動作確認
- [x] ui確認